### PR TITLE
Handle IPDEF-only Vivado IP metadata

### DIFF
--- a/src/vivado_mcp/tcl_scripts.py
+++ b/src/vivado_mcp/tcl_scripts.py
@@ -197,9 +197,15 @@ set __ip [get_ips {ip_name}]
 if {{$__ip eq ""}} {{
     puts "VMCP_IP_PARAM_ERROR:IP '{ip_name}' not found"
 }} else {{
-    set __vlnv [get_property VLNV $__ip]
-    puts "VMCP_IP_INFO:$__vlnv"
     set __props [list_property $__ip]
+    if {{[lsearch -exact $__props VLNV] >= 0}} {{
+        set __vlnv [get_property VLNV $__ip]
+    }} elseif {{[lsearch -exact $__props IPDEF] >= 0}} {{
+        set __vlnv [get_property IPDEF $__ip]
+    }} else {{
+        set __vlnv "<unknown>"
+    }}
+    puts "VMCP_IP_INFO:$__vlnv"
     foreach __p $__props {{
         if {{[string match "CONFIG.*" $__p]}} {{
             set __val [get_property $__p $__ip]
@@ -306,7 +312,14 @@ if {[catch {current_project} __proj]} {
     set __ips [get_ips -quiet]
     puts "VMCP_PROJ:ip_count=[llength $__ips]"
     foreach __ip $__ips {
-        set __vlnv [get_property VLNV $__ip]
+        set __ip_props [list_property $__ip]
+        if {[lsearch -exact $__ip_props VLNV] >= 0} {
+            set __vlnv [get_property VLNV $__ip]
+        } elseif {[lsearch -exact $__ip_props IPDEF] >= 0} {
+            set __vlnv [get_property IPDEF $__ip]
+        } else {
+            set __vlnv "<unknown>"
+        }
         puts "VMCP_PROJ_IP:$__ip|$__vlnv"
     }
 

--- a/tests/test_tcl_scripts_ip_metadata.py
+++ b/tests/test_tcl_scripts_ip_metadata.py
@@ -1,0 +1,24 @@
+"""Tests for Tcl snippets that query IP metadata."""
+
+from vivado_mcp.tcl_scripts import INSPECT_IP_PARAMS, QUERY_PROJECT_INFO
+
+
+def test_inspect_ip_params_falls_back_to_ipdef():
+    """Vivado 2018.x IP objects may expose IPDEF instead of VLNV."""
+    tcl = INSPECT_IP_PARAMS.format(ip_name="gtwizard_0")
+
+    assert "set __props [list_property $__ip]" in tcl
+    assert "lsearch -exact $__props VLNV" in tcl
+    assert "lsearch -exact $__props IPDEF" in tcl
+    assert "set __vlnv [get_property IPDEF $__ip]" in tcl
+    assert tcl.index("set __props [list_property $__ip]") < tcl.index(
+        "get_property VLNV $__ip"
+    )
+
+
+def test_query_project_info_falls_back_to_ipdef():
+    """Project IP listing should use IPDEF when VLNV is unavailable."""
+    assert "set __ip_props [list_property $__ip]" in QUERY_PROJECT_INFO
+    assert "lsearch -exact $__ip_props VLNV" in QUERY_PROJECT_INFO
+    assert "lsearch -exact $__ip_props IPDEF" in QUERY_PROJECT_INFO
+    assert "set __vlnv [get_property IPDEF $__ip]" in QUERY_PROJECT_INFO


### PR DESCRIPTION
<!-- 感谢贡献!提交前请确认以下几条 -->

## 改动说明

兼容 Vivado 2018.x 中 IP 对象只有 `IPDEF`、没有 `VLNV` 属性的情况，避免 `inspect_ip_params` 和项目 IP 列表查询在读取 IP 元数据时提前失败。

具体改动：

- `INSPECT_IP_PARAMS` 先通过 `list_property` 检查 IP 对象属性。
- 优先读取 `VLNV`，不存在时 fallback 到 `IPDEF`。
- 同样修复 `QUERY_PROJECT_INFO` 中 IP 列表的 `VLNV` 裸读取。
- 新增 Tcl 模板回归测试，确保后续不会退回到裸 `get_property VLNV`。

## 关联 issue

无

## 自检清单

- [x] 跑过 `pytest -v`,所有测试 pass
- [x] 跑过 `ruff check src/ tests/`,无新增警告
- [x] 改了行为的话,**新增/更新了对应测试**
- [ ] 改了用户可见行为的话,**更新了 README / CHANGELOG**
- [ ] 如果触及 `vivado/` 协议层 或 `tcl_scripts.py`,我读过了 `.trellis/spec/backend/tcl-protocol-guidelines.md`
  - 说明：当前 checkout 中未找到该文件，路径 `.trellis/spec/backend/tcl-protocol-guidelines.md` 不存在。
- [x] 如果新增 MCP 工具,我确认过**不能**用 `run_tcl` 直接做(参考 README"少即是多"段)
  - 说明：本 PR 未新增 MCP 工具。

## 实机验证(可选但强烈推荐)

- Vivado 2018.3
- Project: `E:\2023\2023_4_J\software_zhengyang\J_ZJ_v1.41\J_ZJ.xpr`
- 现象：`gtwizard_0` 等 IP 对象没有 `VLNV` 属性，但有 `IPDEF` 属性。
- 复现失败点：
  - 原 `inspect_ip_params(ip_name="gtwizard_0", filter_keyword="gt")` 返回：
    - `ERROR: [Common 17-39] 'get_property' failed due to earlier errors.`
- 实机确认：
  - `get_property VLNV [get_ips gtwizard_0]` 失败。
  - `get_property IPDEF [get_ips gtwizard_0]` 返回 `xilinx.com:ip:gtwizard:3.6`。
  - `list_property [get_ips gtwizard_0]` 可正常列出 `CONFIG.*` 参数。
  - fallback 到 `IPDEF` 后，可正常读取 GT 相关参数。

本地验证命令：

```powershell
python -m ruff check src/ tests/
All checks passed!
$env:PYTHONPATH='src'
python -m pytest tests/test_tcl_scripts_ip_metadata.py tests/test_ip_tools.py -q
756 passed
