### PR TITLE
server: migrate imports to MCP Python SDK v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
-dependencies = ["mcp>=1.0.0"]
+dependencies = ["mcp>=2.0.0,<3"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.4"]

--- a/src/vivado_mcp/server.py
+++ b/src/vivado_mcp/server.py
@@ -1,7 +1,7 @@
-"""FastMCP 服务器实例、lifespan 管理、工具注册、Resources & Prompts。
+"""MCPServer 服务器实例、lifespan 管理、工具注册、Resources & Prompts。
 
 架构：
-  Claude Code ──(stdio)──▶ FastMCP Server
+  Claude Code ──(stdio)──▶ MCPServer
                                 │
                           SessionManager (lifespan context)
                           ├─ "default" ──▶ vivado -mode tcl
@@ -16,7 +16,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from vivado_mcp.config import find_vivado
 from vivado_mcp.vivado.session import VivadoSession
@@ -44,7 +44,7 @@ class AppContext:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
+async def app_lifespan(server: MCPServer) -> AsyncIterator[AppContext]:
     """MCP 服务器生命周期管理。
 
     启动时初始化 SessionManager，关闭时清理所有 Vivado 会话。
@@ -69,8 +69,8 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         await manager.close_all()
 
 
-# 创建 FastMCP 实例
-mcp = FastMCP(
+# 创建 MCPServer 实例
+mcp = MCPServer(
     "vivado-mcp",
     lifespan=app_lifespan,
 )

--- a/src/vivado_mcp/tools/diagnostic_tools.py
+++ b/src/vivado_mcp/tools/diagnostic_tools.py
@@ -6,7 +6,7 @@
 
 import logging
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis.io_parser import parse_report_io
 from vivado_mcp.analysis.io_verifier import format_io_verification, verify_io_placement

--- a/src/vivado_mcp/tools/flow_tools.py
+++ b/src/vivado_mcp/tools/flow_tools.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import time
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis.warning_parser import parse_diag_counts, parse_pre_bitstream
 from vivado_mcp.server import _NO_SESSION, _require_session, _safe_execute, mcp

--- a/src/vivado_mcp/tools/introspect_tools.py
+++ b/src/vivado_mcp/tools/introspect_tools.py
@@ -11,7 +11,7 @@
   - parse_ltx     —— get_hw_probes 需板子在手 + 活 hw session;离线读探针清单。
 """
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis.bit_header_parser import format_bit as _format_bit
 from vivado_mcp.analysis.bit_header_parser import parse_bit as _parse_bit

--- a/src/vivado_mcp/tools/ip_tools.py
+++ b/src/vivado_mcp/tools/ip_tools.py
@@ -4,7 +4,7 @@ inspect_ip_params 通过 Vivado Tcl API 查询 IP 实例的所有 CONFIG.* 参�
 compare_xci 纯 Python 解析两个 XCI 文件并对比参数差异，无需 Vivado 会话。
 """
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis.ip_param_parser import parse_ip_params
 from vivado_mcp.analysis.xci_parser import (

--- a/src/vivado_mcp/tools/report_tools.py
+++ b/src/vivado_mcp/tools/report_tools.py
@@ -8,7 +8,7 @@
 import json
 import logging
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis.io_parser import parse_report_io
 from vivado_mcp.analysis.ip_status_parser import format_ip_status_report, parse_ip_status

--- a/src/vivado_mcp/tools/session_tools.py
+++ b/src/vivado_mcp/tools/session_tools.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.server import _get_manager, mcp
 

--- a/src/vivado_mcp/tools/tcl_tools.py
+++ b/src/vivado_mcp/tools/tcl_tools.py
@@ -9,7 +9,7 @@
   Windows 路径含空格 / 中文 / ``$`` / ``[]`` / ``{}`` / 反斜杠也能安全执行
 """
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.server import _NO_SESSION, _require_session, _safe_execute, mcp
 from vivado_mcp.vivado.tcl_utils import tcl_quote

--- a/src/vivado_mcp/tools/wave_tools.py
+++ b/src/vivado_mcp/tools/wave_tools.py
@@ -18,7 +18,7 @@ AI 极易搞砸"的本地价值：
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from vivado_mcp.analysis import wcfg_editor
 from vivado_mcp.server import _NO_SESSION, _require_session, mcp
@@ -191,7 +191,7 @@ async def set_wave_zoom(
         wcfg_editor.set_zoom_range(wcfg_path, start_ns, end_ns)
     except (OSError, ValueError) as e:
         # OSError 覆盖 FileNotFoundError/PermissionError(只读/占用/无写权限),
-        # 写回阶段的失败也要带具体原因返回,不能裸抛成 FastMCP 通用错误
+        # 写回阶段的失败也要带具体原因返回,不能裸抛成 MCPServer 通用错误
         return f"[ERROR] 改写 wcfg 缩放区间失败: {type(e).__name__}: {e}"
 
     # 路径必须过 to_tcl_path 转义(转正斜杠 + 引号包裹):含空格/$/[ 的合法


### PR DESCRIPTION
## Summary
Adapt the project to MCP Python SDK v2 where `mcp.server.fastmcp` no longer exists.

## Changes
- Replace server class import:
  - `mcp.server.fastmcp.FastMCP` -> `mcp.server.MCPServer`
- Replace all tool context imports:
  - `mcp.server.fastmcp.Context` -> `mcp.server.mcpserver.Context`
- Update dependency constraint in `pyproject.toml`:
  - `mcp>=1.0.0` -> `mcp>=2.0.0,<3`
- Update related in-file wording/comments from FastMCP to MCPServer.

## Why
`pip install mcp` now resolves to v2 by default, and v2 removed `mcp.server.fastmcp`. This change prevents import failures and keeps the codebase compatible with the latest stable MCP SDK.

## Validation
Executed with the project virtual environment (`.venv`):
- `python -m compileall src`
- `python -m ruff check src tests`

Both checks passed.